### PR TITLE
Record with default null value

### DIFF
--- a/src/main/java/net/coru/kloadgen/processor/AvroSchemaProcessor.java
+++ b/src/main/java/net/coru/kloadgen/processor/AvroSchemaProcessor.java
@@ -21,10 +21,12 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
+import static org.apache .avro.Schema.Type.ARRAY;
+import static org.apache.avro.Schema.Type.MAP;
+import static org.apache.avro.Schema.Type.RECORD;
+import static org.apache.avro.Schema.Type.UNION;
 
 import java.util.*;
-
-import static org.apache.avro.Schema.Type.*;
 
 public class AvroSchemaProcessor {
 

--- a/src/main/java/net/coru/kloadgen/processor/AvroSchemaProcessor.java
+++ b/src/main/java/net/coru/kloadgen/processor/AvroSchemaProcessor.java
@@ -1,3 +1,4 @@
+
 /*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -6,8 +7,19 @@
 
 package net.coru.kloadgen.processor;
 
+import static org.apache .avro.Schema.Type.ARRAY;
+import static org.apache.avro.Schema.Type.MAP;
+import static org.apache.avro.Schema.Type.RECORD;
+import static org.apache.avro.Schema.Type.UNION;
+
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import lombok.SneakyThrows;
 import net.coru.kloadgen.exception.KLoadGenException;
 import net.coru.kloadgen.model.FieldValueMapping;
@@ -21,12 +33,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
-import static org.apache .avro.Schema.Type.ARRAY;
-import static org.apache.avro.Schema.Type.MAP;
-import static org.apache.avro.Schema.Type.RECORD;
-import static org.apache.avro.Schema.Type.UNION;
-
-import java.util.*;
 
 public class AvroSchemaProcessor {
 

--- a/src/main/java/net/coru/kloadgen/processor/AvroSchemaProcessor.java
+++ b/src/main/java/net/coru/kloadgen/processor/AvroSchemaProcessor.java
@@ -1,4 +1,3 @@
-
 /*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  * License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
Hi!

If we have complex nested record type with default null value like:
{"name": "fix", "type": ["null", "type": {"type": "record", "name": "nestedRecord"}], "default": null}
that will fall with exception in method AvroSchemaProcessor.extractType, cause thing that is an array.

And it can't parse complex schema with nested records with similar names, which represents in fieldValue mapping
like fizzbuzz.fizz.fizzbuzz.
In this case "fizzbuzz.fizz.fizzbuzz".contains("fizz") will be always true for first part of field name.
To solve this problem i add some checking by regexp.