### PR TITLE
fix: change kafka_2.13 for kafka-clients dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.13</artifactId>
+      <artifactId>kafka-clients</artifactId>
       <version>${kafka.version}</version>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
kafka_2.13 brings scala dependencies on the shaded artifacts which can cause trouble.

On the OctoPerf Sass platform, the injector throws this king of exception :

```
Uncaught Exception com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.2 requires Jackson Databind version >= 2.10.0 and < 2.11.0 in thread Thread[StandardJMeterEngine,5,main]. See log file for details.
```