### PR TITLE
Use field name rather than first field list value as context key

### DIFF
--- a/src/main/java/net/coru/kloadgen/processor/SchemaProcessorLib.java
+++ b/src/main/java/net/coru/kloadgen/processor/SchemaProcessorLib.java
@@ -152,7 +152,7 @@ public abstract class SchemaProcessorLib {
         if ("seq".equals(fieldType)) {
             if (!fieldValuesList.isEmpty() && '{' == fieldValuesList.get(0).charAt(0)) {
                 parameterList.set(0, parameterList.get(0).substring(1));
-                value.put(generateMapKey(), randomObject.generateSequenceForFieldValueList(parameterList.get(0), fieldType, parameterList, context));
+                value.put(generateMapKey(), randomObject.generateSequenceForFieldValueList(fieldName, fieldType, parameterList, context));
             }
             for (int i = mapSize; i > 0; i--) {
                 value.put(generateMapKey(),
@@ -177,7 +177,7 @@ public abstract class SchemaProcessorLib {
         if ("seq".equals(fieldType)) {
             if (!fieldValuesList.isEmpty() && '{' == fieldValuesList.get(0).charAt(0)) {
                 parameterList.set(0, parameterList.get(0).substring(1));
-                value.add(randomObject.generateSequenceForFieldValueList(parameterList.get(0), fieldType, parameterList, context));
+                value.add(randomObject.generateSequenceForFieldValueList(fieldName, fieldType, parameterList, context));
             } else {
                 for (int i = arraySize; i > 0; i--) {
                     value.add(randomObject.generateSeq(fieldName, fieldType, parameterList, context));

--- a/src/main/java/net/coru/kloadgen/randomtool/generator/AvroGeneratorTool.java
+++ b/src/main/java/net/coru/kloadgen/randomtool/generator/AvroGeneratorTool.java
@@ -33,24 +33,7 @@ public class AvroGeneratorTool {
 
   private final Map<String, Object> context = new HashMap<>();
 
-  private final RandomMap randomMap = new RandomMap();
-
-  private final RandomArray randomArray = new RandomArray();
-
   private final RandomObject randomObject = new RandomObject();
-
-  public Object generateMap(String fieldType, Integer valueLength, List<String> fieldValuesList, Integer size) {
-    List<String> parameterList = ValueUtils.replaceValuesContext(fieldValuesList);
-    return randomMap.generateMap(fieldType, valueLength, parameterList, size, Collections.emptyMap());
-  }
-
-  public Object generateArray(String fieldType, Integer arraySize, Integer valueLength, List<String> fieldValuesList) {
-    List<String> parameterList = ValueUtils.replaceValuesContext(fieldValuesList);
-    return randomArray.generateArray(fieldType, valueLength, parameterList, arraySize, Collections.emptyMap());
-  }
-
-
-
 
   public Object generateObject(Field field, String fieldType, Integer valueLength, List<String> fieldValuesList, Map<ConstraintTypeEnum, String> constrains) {
     List<String> parameterList = ValueUtils.replaceValuesContext(fieldValuesList);
@@ -58,7 +41,7 @@ public class AvroGeneratorTool {
 
     Object value;
     if (ENUM == field.schema().getType()) {
-      value = getEnumOrGenerate(fieldType, field.schema(), parameterList);
+      value = getEnumOrGenerate(field.name(), fieldType, field.schema(), parameterList);
     }else if (UNION == field.schema().getType()) {
       Schema safeSchema = getRecordUnion(field.schema().getTypes());
       if (differentTypesNeedCast(fieldType, safeSchema.getType())) {
@@ -66,7 +49,7 @@ public class AvroGeneratorTool {
         value = randomObject.generateRandom(fieldType, valueLength, parameterList, constrains);
         value = ValueUtils.castValue(value, field.schema().getType().getName());
       } else if (ENUM == safeSchema.getType()) {
-        value = getEnumOrGenerate(fieldType, safeSchema, parameterList);
+        value = getEnumOrGenerate(field.name(), fieldType, safeSchema, parameterList);
       } else {
         value = randomObject.generateRandom(fieldType, valueLength, parameterList, constrains);
         if ("null".equalsIgnoreCase(value.toString())) {
@@ -76,7 +59,7 @@ public class AvroGeneratorTool {
     } else if ("seq".equalsIgnoreCase(fieldType)) {
       if (!fieldValuesList.isEmpty() && '{' == fieldValuesList.get(0).charAt(0)) {
         fieldValuesList.set(0, fieldValuesList.get(0).substring(1));
-        return randomObject.generateSequenceForFieldValueList(fieldValuesList.get(0), fieldType, fieldValuesList, context);
+        return randomObject.generateSequenceForFieldValueList(field.name(), fieldType, fieldValuesList, context);
       }else {
         value = randomObject.generateSeq(field.name(), field.schema().getType().getName(), parameterList, context);
       }
@@ -143,7 +126,7 @@ public class AvroGeneratorTool {
     }
   }
 
-  private Object getEnumOrGenerate(String fieldType, Schema schema, List<String> parameterList) {
+  private Object getEnumOrGenerate(String fieldName, String fieldType, Schema schema, List<String> parameterList) {
     Object value;
     if ("ENUM".equalsIgnoreCase(fieldType)) {
       if (parameterList.isEmpty()) {
@@ -152,7 +135,7 @@ public class AvroGeneratorTool {
       } else {
         if ('{'== parameterList.get(0).charAt(0)) {
           parameterList.set(0, parameterList.get(0).substring(1));
-          value = new GenericData.EnumSymbol(schema, randomObject.generateSequenceForFieldValueList(parameterList.get(0),fieldType,parameterList,context));
+          value = new GenericData.EnumSymbol(schema, randomObject.generateSequenceForFieldValueList(fieldName,fieldType,parameterList,context));
         } else {
           value = new GenericData.EnumSymbol(schema, parameterList.get(RandomUtils.nextInt(0, parameterList.size())));
         }

--- a/src/main/java/net/coru/kloadgen/randomtool/generator/StatelessGeneratorTool.java
+++ b/src/main/java/net/coru/kloadgen/randomtool/generator/StatelessGeneratorTool.java
@@ -33,7 +33,7 @@ public class StatelessGeneratorTool {
     if ("seq".equals(fieldType)) {
       if (!fieldValuesList.isEmpty() && '{' == fieldValuesList.get(0).charAt(0)) {
         fieldValuesList.set(0, fieldValuesList.get(0).substring(1));
-        return randomObject.generateSequenceForFieldValueList(fieldValuesList.get(0), fieldType, fieldValuesList, context);
+        return randomObject.generateSequenceForFieldValueList(fieldName, fieldType, fieldValuesList, context);
       } else {
         value = randomObject.generateSeq(fieldName, fieldType, parameterList, context);
       }

--- a/src/test/java/net/coru/kloadgen/processor/AvroSchemaProcessorTest.java
+++ b/src/test/java/net/coru/kloadgen/processor/AvroSchemaProcessorTest.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import com.google.common.collect.Streams;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import net.coru.kloadgen.exception.KLoadGenException;
@@ -42,6 +43,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 
 import static net.coru.kloadgen.processor.fixture.AvroSchemaFixturesConstants.ARRAY_OPTIONAL_NULL;
 import static net.coru.kloadgen.processor.fixture.AvroSchemaFixturesConstants.ARRAY_OPTIONAL_NULL_FIELDS;
@@ -370,7 +372,6 @@ class AvroSchemaProcessorTest {
 
         assertThat(message)
             .isNotNull()
-            .isInstanceOf(EnrichedRecord.class)
             .extracting(EnrichedRecord::getGenericRecord)
             .isNotNull();
 
@@ -378,5 +379,57 @@ class AvroSchemaProcessorTest {
         assertThat(record.get(0)).isNotNull();
         assertThat(record.get(1)).isNull();
 
+    }
+
+    private GenericRecord entityWithSequences(Schema schema, List<String> idValues, List<String> otherIdValues) {
+        GenericRecord entity = new GenericData.Record(schema);
+        Schema valuesSchema = entity.getSchema().getField("values").schema();
+        Schema valuesDataSchema = valuesSchema.getElementType();
+        List<GenericRecord> valuesData = Streams.zip(idValues.stream(), otherIdValues.stream(), (id, otherId) -> {
+            GenericRecord valuesDataRecord = new GenericData.Record(valuesDataSchema);
+            valuesDataRecord.put("id", id);
+            valuesDataRecord.put("otherId", otherId);
+            return valuesDataRecord;
+        }).collect(toList());
+
+        entity.put("values", valuesData);
+        return entity;
+    }
+
+    @Test
+    void testCustomSequenceOfValues() {
+        List<FieldValueMapping> fieldValueMappingList = asList(
+                new FieldValueMapping("values[3].id", "seq", 0, "[{1,2]"),
+                new FieldValueMapping("values[3].otherId", "seq", 0, "[{1,3]"));
+
+        AvroSchemaProcessor avroSchemaProcessor = new AvroSchemaProcessor();
+        Schema schemaWithTwoSequencesWithSameStartingValue = SchemaBuilder
+                .builder()
+                .record("Root")
+                .fields()
+                .name("values")
+                .type()
+                .array()
+                .items()
+                .type(SchemaBuilder.builder()
+                        .record("valuesData")
+                        .fields()
+                        .name("id")
+                        .type(Schema.Type.STRING.getName())
+                        .noDefault()
+                        .name("otherId")
+                        .type(Schema.Type.STRING.getName())
+                        .noDefault()
+                        .endRecord())
+                .noDefault()
+                .endRecord();
+        GenericRecord entity = entityWithSequences(schemaWithTwoSequencesWithSameStartingValue, asList("1", "2", "1"), asList("1", "3", "1"));
+        avroSchemaProcessor.processSchema(schemaWithTwoSequencesWithSameStartingValue,
+                new SchemaMetadata(1, 1, ""),
+                fieldValueMappingList);
+
+        EnrichedRecord message = avroSchemaProcessor.next();
+
+        assertThat(message.getGenericRecord()).isEqualTo(entity);
     }
 }


### PR DESCRIPTION
This avoids the issue that if two field value lists start with the same value, that those lists influence each other.

An issue remains. The field name is also not unique as two records in one schema can have a field with the same name, but maybe less often ambiguous compared to the first value of a field value list. At least now it is consistent with other calls to `generateSequenceForFieldValueList`.

---

The issue we experiences was the following:

|Field Name         |Field Type|Field Value List|
|-----------------|----------|----------------|
|values[3].id         |seq          |[{1,2]|
|values[3].otherId|seq          |[{1,3]|

The resulting record would the always look like this:
```
{
  values: [
    {id: 1, otherId: 3},
    {id: 1, otherId: 3},
    {id: 1, otherId: 3}
  ]
}
```
while we expected the sequence to be independent and be used in the following way:
```
{
  values: [
    {id: 1, otherId: 1},
    {id: 2, otherId: 3},
    {id: 1, otherId: 1}
  ]
}
```

The issue was that the first element of a sequence was passed into `generateSequenceForFieldValueList` rather than the field name as the method signature suggested.

The field name is also not unique though, which can lead to other issues, like using the same field name in two different records both with custom sequences. IMHO, the current solution fixes some of the issues currently observed with custom field value lists.

If you have other suggestions please let me know.