### PR TITLE
Fix sequence casts

### DIFF
--- a/pom-github.xml
+++ b/pom-github.xml
@@ -6,7 +6,7 @@
   <groupId>net.coru</groupId>
 
   <artifactId>kloadgen</artifactId>
-  <version>3.8.2</version>
+  <version>3.8.3</version>
 
   <distributionManagement>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>net.coru</groupId>
 
   <artifactId>kloadgen</artifactId>
-  <version>3.8.2</version>
+  <version>3.8.3</version>
 
   <properties>
     <assertj-core.version>3.18.1</assertj-core.version>

--- a/src/main/java/net/coru/kloadgen/processor/AvroSchemaProcessor.java
+++ b/src/main/java/net/coru/kloadgen/processor/AvroSchemaProcessor.java
@@ -400,29 +400,6 @@ public class AvroSchemaProcessor extends SchemaProcessorLib {
         return isRecord;
     }
 
-    private Object createArray(Schema subSchema, String fieldName, Integer arraySize, Integer fieldValueLength, ArrayDeque<FieldValueMapping> fieldExpMappingsQueue) {
-        if (ARRAY.equals(subSchema.getType())) {
-            if (typesSet.contains(subSchema.getElementType().getType())) {
-                return createArray(fieldName, arraySize, fieldExpMappingsQueue);
-            } else if (MAP.equals(subSchema.getElementType().getType())) {
-                fieldExpMappingsQueue.remove();
-                return createSimpleTypeMap(fieldName, subSchema.getElementType().getValueType().getType().getName(), arraySize, fieldValueLength, Collections.emptyList());
-            } else {
-                return createObjectArray(subSchema.getElementType(), fieldName, arraySize, fieldExpMappingsQueue);
-            }
-        } else if (MAP.equals(subSchema.getType())) {
-            if (ARRAY.equals(subSchema.getValueType().getType())) {
-                return createArray(fieldName, arraySize, fieldExpMappingsQueue);
-            } else {
-                return createObjectArray(subSchema, fieldName, arraySize, fieldExpMappingsQueue);
-            }
-        } else if (typesSet.contains(subSchema.getType())) {
-            return createArray(fieldName, arraySize, fieldExpMappingsQueue);
-        } else {
-            return createObjectArray(subSchema, fieldName, arraySize, fieldExpMappingsQueue);
-        }
-    }
-
     private List<GenericRecord> createObjectArray(Schema subSchema, String fieldName, Integer arraySize, ArrayDeque<FieldValueMapping> fieldExpMappingsQueue) {
         List<GenericRecord> objectArray = new ArrayList<>(arraySize);
         for (int i = 0; i < arraySize - 1; i++) {

--- a/src/main/java/net/coru/kloadgen/processor/SchemaProcessorLib.java
+++ b/src/main/java/net/coru/kloadgen/processor/SchemaProcessorLib.java
@@ -203,10 +203,6 @@ public abstract class SchemaProcessorLib {
         return generateRandomMap(fieldName, fieldType, mapSize, fieldValueLength, 0, fieldExpMappings);
     }
 
-    static List<Map> createSimpleTypeMapArray(String fieldName, String fieldType, Integer arraySize, Integer mapSize, Integer fieldValueLength, List<String> fieldExpMappings) {
-        return (List<Map>) generateRandomMap(fieldName, fieldType, mapSize, fieldValueLength, arraySize, fieldExpMappings);
-    }
-
     static Map<String, Object> createSimpleTypeArrayMap(String fieldName, String fieldType, Integer arraySize, Integer mapSize, Integer fieldValueLength, List<String> fieldExpMappings) {
         Map<String, Object> result = new HashMap<>(mapSize);
         String type = fieldType;

--- a/src/main/java/net/coru/kloadgen/randomtool/generator/AvroGeneratorTool.java
+++ b/src/main/java/net/coru/kloadgen/randomtool/generator/AvroGeneratorTool.java
@@ -6,20 +6,18 @@
 
 package net.coru.kloadgen.randomtool.generator;
 
+import static net.coru.kloadgen.randomtool.util.ValueUtils.getValidTypeFromSchema;
 import static org.apache.avro.Schema.Type.ENUM;
 import static org.apache.avro.Schema.Type.FIXED;
 import static org.apache.avro.Schema.Type.NULL;
 import static org.apache.avro.Schema.Type.UNION;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import net.coru.kloadgen.model.ConstraintTypeEnum;
 import net.coru.kloadgen.model.FieldValueMapping;
-import net.coru.kloadgen.randomtool.random.RandomArray;
-import net.coru.kloadgen.randomtool.random.RandomMap;
 import net.coru.kloadgen.randomtool.random.RandomObject;
 import net.coru.kloadgen.randomtool.util.ValueUtils;
 import org.apache.avro.Schema;
@@ -64,9 +62,9 @@ public class AvroGeneratorTool {
     } else if ("seq".equalsIgnoreCase(fieldType)) {
       if (!fieldValuesList.isEmpty() && '{' == fieldValuesList.get(0).charAt(0)) {
         fieldValuesList.set(0, fieldValuesList.get(0).substring(1));
-        return randomObject.generateSequenceForFieldValueList(fieldValueMapping.getFieldName(), fieldType, fieldValuesList, context);
+        return randomObject.generateSequenceForFieldValueList(fieldValueMapping.getFieldName(), getValidTypeFromSchema(field.schema()), fieldValuesList, context);
       }else {
-        value = randomObject.generateSeq(field.name(), field.schema().getType().getName(), parameterList, context);
+        value = randomObject.generateSeq(field.name(), getValidTypeFromSchema(field.schema()), parameterList, context);
       }
     } else if (differentTypesNeedCast(fieldType, field.schema().getType())) {
 

--- a/src/main/java/net/coru/kloadgen/randomtool/generator/AvroGeneratorTool.java
+++ b/src/main/java/net/coru/kloadgen/randomtool/generator/AvroGeneratorTool.java
@@ -63,7 +63,7 @@ public class AvroGeneratorTool {
       if (!fieldValuesList.isEmpty() && '{' == fieldValuesList.get(0).charAt(0)) {
         fieldValuesList.set(0, fieldValuesList.get(0).substring(1));
         return randomObject.generateSequenceForFieldValueList(fieldValueMapping.getFieldName(), getValidTypeFromSchema(field.schema()), fieldValuesList, context);
-      }else {
+      } else {
         value = randomObject.generateSeq(field.name(), getValidTypeFromSchema(field.schema()), parameterList, context);
       }
     } else if (differentTypesNeedCast(fieldType, field.schema().getType())) {

--- a/src/main/java/net/coru/kloadgen/randomtool/random/RandomObject.java
+++ b/src/main/java/net/coru/kloadgen/randomtool/random/RandomObject.java
@@ -34,8 +34,6 @@ import org.apache.commons.lang3.StringUtils;
 
 public class RandomObject {
 
-  private static final Map<String, Object> context = new HashMap<>();
-
   public boolean isTypeValid(String type) {
     return ValidTypeConstants.VALID_OBJECT_TYPES.contains(type);
   }

--- a/src/main/java/net/coru/kloadgen/randomtool/util/ValueUtils.java
+++ b/src/main/java/net/coru/kloadgen/randomtool/util/ValueUtils.java
@@ -33,61 +33,62 @@ public class ValueUtils {
     return parameterList;
   }
 
-  public static Object castValue(Object value, String type) {
+  public static Object castValue(Object valueObject, String type) {
     Object castValue;
+    String value = valueObject.toString();
     switch (type) {
       case ValidTypeConstants.INT:
-        castValue = Integer.valueOf(value.toString());
+        castValue = Integer.valueOf(value);
         break;
       case ValidTypeConstants.DOUBLE:
-        castValue = Double.valueOf(value.toString());
+        castValue = Double.valueOf(value);
         break;
       case ValidTypeConstants.LONG:
-        castValue = Long.valueOf(value.toString());
+        castValue = Long.valueOf(value);
         break;
       case ValidTypeConstants.FLOAT:
-        castValue = Float.valueOf(value.toString());
+        castValue = Float.valueOf(value);
         break;
       case ValidTypeConstants.SHORT:
-        castValue = Short.valueOf(value.toString());
+        castValue = Short.valueOf(value);
         break;
       case ValidTypeConstants.BOOLEAN:
-        castValue = Boolean.valueOf(value.toString());
+        castValue = Boolean.valueOf(value);
         break;
       case ValidTypeConstants.TIMESTAMP:
-        castValue = LocalDateTime.parse(value.toString().trim());
+        castValue = LocalDateTime.parse(value.trim());
         break;
       case ValidTypeConstants.LONG_TIMESTAMP:
-        castValue = LocalDateTime.parse(value.toString().trim()).toInstant(ZoneOffset.UTC).toEpochMilli();
+        castValue = LocalDateTime.parse(value.trim()).toInstant(ZoneOffset.UTC).toEpochMilli();
         break;
       case ValidTypeConstants.STRING_TIMESTAMP:
-        castValue = LocalDateTime.parse(value.toString().trim()).toString();
+        castValue = LocalDateTime.parse(value.trim()).toString();
         break;
       case ValidTypeConstants.INT_DATE:
-        castValue = LocalDate.parse(value.toString().trim());
+        castValue = LocalDate.parse(value.trim());
         break;
       case ValidTypeConstants.INT_TIME_MILLIS:
       case ValidTypeConstants.LONG_TIME_MICROS:
-        castValue = LocalTime.parse(value.toString().trim());
+        castValue = LocalTime.parse(value.trim());
         break;
       case ValidTypeConstants.LONG_TIMESTAMP_MILLIS:
       case ValidTypeConstants.LONG_TIMESTAMP_MICROS:
-        castValue = LocalDateTime.parse(value.toString().trim()).toInstant(ZoneOffset.UTC);
+        castValue = LocalDateTime.parse(value.trim()).toInstant(ZoneOffset.UTC);
         break;
       case ValidTypeConstants.LONG_LOCAL_TIMESTAMP_MILLIS:
       case ValidTypeConstants.LONG_LOCAL_TIMESTAMP_MICROS:
-        castValue = LocalDateTime.parse(value.toString().trim());
+        castValue = LocalDateTime.parse(value.trim());
         break;
       case ValidTypeConstants.UUID:
       case ValidTypeConstants.STRING_UUID:
-        castValue = UUID.fromString(value.toString());
+        castValue = UUID.fromString(value);
         break;
       case ValidTypeConstants.BYTES_DECIMAL:
       case ValidTypeConstants.FIXED_DECIMAL:
-        castValue = new BigDecimal(value.toString());
+        castValue = new BigDecimal(value);
         break;
       default:
-        castValue = value.toString();
+        castValue = value;
         break;
     }
     return castValue;

--- a/src/main/java/net/coru/kloadgen/randomtool/util/ValueUtils.java
+++ b/src/main/java/net/coru/kloadgen/randomtool/util/ValueUtils.java
@@ -6,9 +6,17 @@
 
 package net.coru.kloadgen.randomtool.util;
 
+import org.apache.avro.Schema;
+import org.apache.jmeter.threads.JMeterContextService;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.jmeter.threads.JMeterContextService;
+import java.util.UUID;
 
 public class ValueUtils {
 
@@ -40,13 +48,54 @@ public class ValueUtils {
       case ValidTypeConstants.FLOAT:
         castValue = Float.valueOf(value.toString());
         break;
+      case ValidTypeConstants.SHORT:
+        castValue = Short.valueOf(value.toString());
+        break;
       case ValidTypeConstants.BOOLEAN:
         castValue = Boolean.valueOf(value.toString());
+        break;
+      case ValidTypeConstants.TIMESTAMP:
+        castValue = LocalDateTime.parse(value.toString().trim());
+        break;
+      case ValidTypeConstants.LONG_TIMESTAMP:
+        castValue = LocalDateTime.parse(value.toString().trim()).toInstant(ZoneOffset.UTC).toEpochMilli();
+        break;
+      case ValidTypeConstants.STRING_TIMESTAMP:
+        castValue = LocalDateTime.parse(value.toString().trim()).toString();
+        break;
+      case ValidTypeConstants.INT_DATE:
+        castValue = LocalDate.parse(value.toString().trim());
+        break;
+      case ValidTypeConstants.INT_TIME_MILLIS:
+      case ValidTypeConstants.LONG_TIME_MICROS:
+        castValue = LocalTime.parse(value.toString().trim());
+        break;
+      case ValidTypeConstants.LONG_TIMESTAMP_MILLIS:
+      case ValidTypeConstants.LONG_TIMESTAMP_MICROS:
+        castValue = LocalDateTime.parse(value.toString().trim()).toInstant(ZoneOffset.UTC);
+        break;
+      case ValidTypeConstants.LONG_LOCAL_TIMESTAMP_MILLIS:
+      case ValidTypeConstants.LONG_LOCAL_TIMESTAMP_MICROS:
+        castValue = LocalDateTime.parse(value.toString().trim());
+        break;
+      case ValidTypeConstants.UUID:
+      case ValidTypeConstants.STRING_UUID:
+        castValue = UUID.fromString(value.toString());
+        break;
+      case ValidTypeConstants.BYTES_DECIMAL:
+      case ValidTypeConstants.FIXED_DECIMAL:
+        castValue = new BigDecimal(value.toString());
         break;
       default:
         castValue = value.toString();
         break;
     }
     return castValue;
+  }
+
+  public static String getValidTypeFromSchema(Schema schema) {
+    return schema.getLogicalType() == null
+            ? schema.getType().getName()
+            : String.format("%s_%s", schema.getType().getName(), schema.getLogicalType().getName());
   }
 }

--- a/src/test/java/net/coru/kloadgen/processor/AvroSchemaProcessorTest.java
+++ b/src/test/java/net/coru/kloadgen/processor/AvroSchemaProcessorTest.java
@@ -388,7 +388,7 @@ class AvroSchemaProcessorTest {
         List<GenericRecord> valuesData = Streams.zip(idValues.stream(), otherIdValues.stream(), (id, otherId) -> {
             GenericRecord valuesDataRecord = new GenericData.Record(valuesDataSchema);
             valuesDataRecord.put("id", id);
-            valuesDataRecord.put("otherId", otherId);
+            valuesDataRecord.put("otherId", Long.valueOf(otherId));
             return valuesDataRecord;
         }).collect(toList());
 
@@ -418,7 +418,7 @@ class AvroSchemaProcessorTest {
                         .type(Schema.Type.STRING.getName())
                         .noDefault()
                         .name("otherId")
-                        .type(Schema.Type.STRING.getName())
+                        .type(Schema.Type.LONG.getName())
                         .noDefault()
                         .endRecord())
                 .noDefault()
@@ -448,7 +448,7 @@ class AvroSchemaProcessorTest {
         Schema schemaContainingId = schemaArrayContainingId.getElementType();
         return idValues.stream().map(id -> {
             GenericRecord recordContainingId = new GenericData.Record(schemaContainingId);
-            recordContainingId.put("id", id);
+            recordContainingId.put("id", new BigDecimal(id));
             return recordContainingId;
         }).collect(toList());
     }
@@ -456,8 +456,10 @@ class AvroSchemaProcessorTest {
     @Test
     void testCustomSequenceOfValuesWithSameFieldNameInDifferentMappings() {
         List<FieldValueMapping> fieldValueMappingList = asList(
-                new FieldValueMapping("values[4].id", "seq", 0, "[{1,2,3]"),
-                new FieldValueMapping("otherValues[4].id", "seq", 0, "[{1,3,4]"));
+                new FieldValueMapping("values[4].id", "seq", 0, "[{1,2.44,3.6]"),
+                new FieldValueMapping("otherValues[4].id", "seq", 0, "[{1,3.02,4.98]"));
+
+        Schema idSchema = LogicalTypes.decimal(5, 2).addToSchema(SchemaBuilder.builder().bytesBuilder().endBytes());
 
         AvroSchemaProcessor avroSchemaProcessor = new AvroSchemaProcessor();
         Schema schemaWithTwoSequencesWithSameStartingValue = SchemaBuilder
@@ -472,7 +474,7 @@ class AvroSchemaProcessorTest {
                         .record("valuesData")
                         .fields()
                         .name("id")
-                        .type(Schema.Type.STRING.getName())
+                        .type(idSchema)
                         .noDefault()
                         .endRecord())
                 .noDefault()
@@ -484,12 +486,12 @@ class AvroSchemaProcessorTest {
                         .record("otherValuesData")
                         .fields()
                         .name("id")
-                        .type(Schema.Type.STRING.getName())
+                        .type(idSchema)
                         .noDefault()
                         .endRecord())
                 .noDefault()
                 .endRecord();
-        GenericRecord entity = entityForCustomSequenceOfValuesWithSameFieldNameInDifferentMappings(schemaWithTwoSequencesWithSameStartingValue, asList("1", "2", "3", "1"), asList("1", "3", "4", "1"));
+        GenericRecord entity = entityForCustomSequenceOfValuesWithSameFieldNameInDifferentMappings(schemaWithTwoSequencesWithSameStartingValue, asList("1", "2.44", "3.6", "1"), asList("1", "3.02", "4.98", "1"));
         avroSchemaProcessor.processSchema(schemaWithTwoSequencesWithSameStartingValue,
                 new SchemaMetadata(1, 1, ""),
                 fieldValueMappingList);

--- a/src/test/java/net/coru/kloadgen/randomtool/generator/AvroGeneratorToolTest.java
+++ b/src/test/java/net/coru/kloadgen/randomtool/generator/AvroGeneratorToolTest.java
@@ -7,6 +7,7 @@
 package net.coru.kloadgen.randomtool.generator;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
@@ -23,7 +24,6 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import net.coru.kloadgen.model.ConstraintTypeEnum;
 import net.coru.kloadgen.model.FieldValueMapping;
-import net.coru.kloadgen.randomtool.random.RandomObject;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
@@ -146,25 +146,26 @@ class AvroGeneratorToolTest {
     assertThat(String.valueOf(number)).hasSize(valueLength);
   }
 
-  private static Stream<Arguments> parametersForGenerateRandomValueWithList() {
+  private static Stream<Arguments> parametersForGenerateFieldValuesListSequence() {
     return Stream.of(
             Arguments.of(18,
-                         List.of("1", "2", "3", "5", "6", "7", "7", "9", "9", "9", "10", "14", "17", "17", "17", "17", "18", "19", "20"),
-                         List.of("1", "2", "3", "5", "6", "7", "7", "9", "9", "9", "10", "14", "17", "17", "17", "17", "18", "19", "20")),
+                    List.of("{1", "2", "3", "5", "6", "7", "7", "9", "9", "9", "10", "14", "17", "17", "17", "17", "18", "19", "20"),
+                    List.of(1, 2, 3, 5, 6, 7, 7, 9, 9, 9, 10, 14, 17, 17, 17, 17, 18, 19, 20)),
             Arguments.of(20,
-                         List.of("1", "2", "3", "5", "6", "7", "7", "9", "9", "9", "10", "14", "17", "17", "17", "17", "18", "19", "20"),
-                         List.of("1", "2", "3", "5", "6", "7", "7", "9", "9", "9", "10", "14", "17", "17", "17", "17", "18", "19", "20", "1", "2")));
+                    List.of("{1", "2", "3", "5", "6", "7", "7", "9", "9", "9", "10", "14", "17", "17", "17", "17", "18", "19", "20"),
+                    List.of(1, 2, 3, 5, 6, 7, 7, 9, 9, 9, 10, 14, 17, 17, 17, 17, 18, 19, 20, 1, 2)));
   }
 
   @ParameterizedTest
-  @DisplayName("Testing Generate a Random Value With a List of Values")
-  @MethodSource("parametersForGenerateRandomValueWithList")
-  void testGenerateRandomValueWithList(int size, List<String> values, List<String> expected) {
-
+  @DisplayName("Testing generate a sequence of a list of values")
+  @MethodSource("parametersForGenerateFieldValuesListSequence")
+  void testGenerateFieldValuesListSequence(int size, List<String> fieldValuesList, List<Integer> expected) {
     var intList = new ArrayList<>();
-    var context = new HashMap<String, Object>();
-    for (int i=0; i <= size; i++) {
-      intList.add(new RandomObject().generateSequenceForFieldValueList("ClientCode", "seq", values, context));
+    Field field = new Field("name", SchemaBuilder.builder().intType());
+    FieldValueMapping fieldValueMapping = new FieldValueMapping(field.name(), "seq", 0, String.join(",", fieldValuesList));
+    AvroGeneratorTool avroGeneratorTool = new AvroGeneratorTool();
+    for (int i = 0; i <= size; i++) {
+      intList.add(avroGeneratorTool.generateObject(field, fieldValueMapping, emptyMap()));
     }
     assertThat(intList).containsExactlyElementsOf(expected);
   }

--- a/src/test/java/net/coru/kloadgen/randomtool/random/RandomObjectTest.java
+++ b/src/test/java/net/coru/kloadgen/randomtool/random/RandomObjectTest.java
@@ -13,16 +13,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import net.coru.kloadgen.model.ConstraintTypeEnum;
 import org.apache.groovy.util.Maps;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,16 +32,6 @@ class RandomObjectTest {
   private static final String TIMESTAMP_STRING = "2019-12-06T10:15:30";
   private static final String DATE_STRING = "2019-12-06";
   private static final String TIME_STRING = "10:15:30";
-
-  private static long getMillisFromDate (LocalDateTime localDateTime){
-    return TimeUnit.MILLISECONDS.convert(localDateTime.toEpochSecond(ZoneOffset.UTC), TimeUnit.SECONDS) +
-            TimeUnit.MILLISECONDS.convert(localDateTime.getNano(), TimeUnit.NANOSECONDS);
-  }
-
-  private static long getMicrosFromDate (LocalDateTime localDateTime){
-    return TimeUnit.MICROSECONDS.convert(localDateTime.toEpochSecond(ZoneOffset.UTC), TimeUnit.SECONDS) +
-            TimeUnit.MICROSECONDS.convert(localDateTime.getNano(), TimeUnit.NANOSECONDS);
-  }
 
   private static Stream<Arguments> parametersForGenerateSingleRandomValue() {
     return Stream.of(
@@ -121,5 +108,27 @@ class RandomObjectTest {
 
     assertThat(new RandomObject().generateSeq(fieldName, fieldType, fieldValuesList, context)).isEqualTo(expectedTyped);
     assertThat(context).containsEntry(fieldName,expectedStored);
+  }
+
+  private static Stream<Arguments> parametersForGenerateRandomValueWithList() {
+    return Stream.of(
+            Arguments.of(18,
+                    List.of("1", "2", "3", "5", "6", "7", "7", "9", "9", "9", "10", "14", "17", "17", "17", "17", "18", "19", "20"),
+                    List.of("1", "2", "3", "5", "6", "7", "7", "9", "9", "9", "10", "14", "17", "17", "17", "17", "18", "19", "20")),
+            Arguments.of(20,
+                    List.of("1", "2", "3", "5", "6", "7", "7", "9", "9", "9", "10", "14", "17", "17", "17", "17", "18", "19", "20"),
+                    List.of("1", "2", "3", "5", "6", "7", "7", "9", "9", "9", "10", "14", "17", "17", "17", "17", "18", "19", "20", "1", "2")));
+  }
+
+  @ParameterizedTest
+  @DisplayName("Testing Generate a Random Value With a List of Values")
+  @MethodSource("parametersForGenerateRandomValueWithList")
+  void testGenerateRandomValueWithList(int size, List<String> values, List<String> expected) {
+    var intList = new ArrayList<>();
+    var context = new HashMap<String, Object>();
+    for (int i=0; i <= size; i++) {
+      intList.add(new RandomObject().generateSequenceForFieldValueList("ClientCode", "seq", values, context));
+    }
+    assertThat(intList).containsExactlyElementsOf(expected);
   }
 }


### PR DESCRIPTION
Cast to correct type if field value mapping uses type "seq"

Field type is then taken from the schema of the field.

ValueUtils#castValue has been adapted for more types. RandomObject#generateRandom was used as reference for ValueUtils#castValue.

---

Previously, if field type was set to `seq`, the type returned from the field value list was always `String`