### PR TITLE
#313 solved serializers casting problems using SpecificDatumWriter

### DIFF
--- a/config/checkstyle/OSS_checkstyle_suppressions.xml
+++ b/config/checkstyle/OSS_checkstyle_suppressions.xml
@@ -5,16 +5,18 @@
   "https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
 
 <suppressions>
-  <suppress checks="VisibilityModifier" files="[/\\].*model.*\.java"/>
-  <suppress checks="VisibilityModifier" files="[/\\].*EnrichedRecord\.java"/>
-  <suppress checks="DesignForExtension" files="[/\\].*model.*\.java"/>
-  <suppress checks="AbstractClassName" files="[/\\].*Field\.java"/>
-  <suppress checks="ClassDataAbstractionCoupling" files="[/\\].*Sampler\.java"/>
-  <suppress checks="ClassDataAbstractionCoupling" files="[/\\].*PropertyEditor\.java"/>
-  <suppress checks="ClassDataAbstractionCoupling" files="[/\\].*ProcessorTest\.java"/>
-  <suppress checks="ClassDataAbstractionCoupling" files="[/\\].*Standalone\.java"/>
-  <suppress checks="ExecutableStatementCount" files="[/\\].*Standalone\.java"/>
-  <suppress checks="AnonInnerLength" files="[/\\].*AutoCompletion\.java"/>
-  <suppress checks="Indentation" files="[/\\].*ExtractorTest\.java"/>
-  <suppress checks="CyclomaticComplexity" files="[/\\].*\.java"/>
+  <suppress checks="VisibilityModifier" files="[/\\].*model.*\.java" />
+  <suppress checks="VisibilityModifier" files="[/\\].*EnrichedRecord\.java" />
+  <suppress checks="DesignForExtension" files="[/\\].*model.*\.java" />
+  <suppress checks="DesignForExtension" files="[/\\].*AvroSerializersTest\.java" />
+  <suppress checks="AbstractClassName" files="[/\\].*Field\.java" />
+  <suppress checks="ClassDataAbstractionCoupling" files="[/\\].*Sampler\.java" />
+  <suppress checks="ClassDataAbstractionCoupling" files="[/\\].*PropertyEditor\.java" />
+  <suppress checks="ClassDataAbstractionCoupling" files="[/\\].*ProcessorTest\.java" />
+  <suppress checks="ClassDataAbstractionCoupling" files="[/\\].*Standalone\.java" />
+  <suppress checks="ClassDataAbstractionCoupling" files="[/\\].*AvroSerializersUtil\.java" />
+  <suppress checks="ExecutableStatementCount" files="[/\\].*Standalone\.java" />
+  <suppress checks="AnonInnerLength" files="[/\\].*AutoCompletion\.java" />
+  <suppress checks="Indentation" files="[/\\].*ExtractorTest\.java" />
+  <suppress checks="CyclomaticComplexity" files="[/\\].*\.java" />
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <artifactId>kloadgen</artifactId>
 
-  <version>5.1.5</version>
+  <version>5.1.4</version>
 
   <name>KLoadGen</name>
   <description>Load Generation Jmeter plugin for Kafka Cluster. Supporting AVRO, JSON Schema and Protobuf schema types. Generate Artificial data base on Data specification</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <artifactId>kloadgen</artifactId>
 
-  <version>5.1.3</version>
+  <version>5.1.5</version>
 
   <name>KLoadGen</name>
   <description>Load Generation Jmeter plugin for Kafka Cluster. Supporting AVRO, JSON Schema and Protobuf schema types. Generate Artificial data base on Data specification</description>
@@ -160,6 +160,17 @@
       <id>dianaGomezGar</id>
       <name>Diana Gómez García</name>
       <email>diana.gomez@sngular.com</email>
+      <organization>Corunet</organization>
+      <organizationUrl>https://corunet.github.io/</organizationUrl>
+      <roles>
+        <role>Junior Developer</role>
+      </roles>
+      <timezone>Europe/Madrid</timezone>
+    </developer>
+    <developer>
+      <id>davidgarciago</id>
+      <name>David García Gondell</name>
+      <email>david.garciag@sngular.com</email>
       <organization>Corunet</organization>
       <organizationUrl>https://corunet.github.io/</organizationUrl>
       <roles>

--- a/schema_registry_docker/conf/kafka/kafka-jaas.conf
+++ b/schema_registry_docker/conf/kafka/kafka-jaas.conf
@@ -1,0 +1,8 @@
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret"
+  user_admin="admin-secret";
+};
+
+Client {};

--- a/schema_registry_docker/docker-compose-kafka-auth.yml
+++ b/schema_registry_docker/docker-compose-kafka-auth.yml
@@ -1,0 +1,53 @@
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SASL_ENABLED: "false"
+  kafka:
+    image: confluentinc/cp-kafka
+    depends_on:
+    - zookeeper
+    ports:
+    - 29092:29092
+    - 9092:9092
+    volumes:
+      - ./conf/kafka/kafka-jaas.conf:/etc/kafka/kafka_server_jaas.conf
+    environment:
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://:9092, SASL_PLAINTEXT://:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,SASL_PLAINTEXT://localhost:29092
+      ZOOKEEPER_SASL_ENABLED: "false"
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf"
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry
+    depends_on:
+    - zookeeper
+    - kafka
+    ports:
+    - 8081:8081
+    volumes:
+    - ./conf:/conf:ro
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181
+      SCHEMA_REGISTRY_AUTHENTICATION_METHOD: BASIC
+      SCHEMA_REGISTRY_AUTHENTICATION_REALM: SchemaRegistry
+      SCHEMA_REGISTRY_AUTHENTICATION_ROLES: Testers
+      SCHEMA_REGISTRY_OPTS: -Djava.security.auth.login.config=/conf/schema-registry/schema-registry.jaas
+  kafka-manager:
+    image: kafkamanager/kafka-manager
+    environment:
+      ZK_HOSTS: zookeeper
+    ports:
+    - 9000:9000

--- a/src/main/java/net/coru/kloadgen/sampler/KafkaConsumerSampler.java
+++ b/src/main/java/net/coru/kloadgen/sampler/KafkaConsumerSampler.java
@@ -19,9 +19,6 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.coru.kloadgen.util.ProducerKeysHelper;
-import org.apache.avro.Conversions;
-import org.apache.avro.data.TimeConversions;
-import org.apache.avro.generic.GenericData;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient;
 import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
@@ -45,7 +42,6 @@ public class KafkaConsumerSampler extends AbstractJavaSamplerClient implements S
     final var props = properties(context);
     final var topic = context.getParameter(ProducerKeysHelper.KAFKA_TOPIC_CONFIG);
     consumer = new KafkaConsumer<>(props);
-    configGenericData();
 
     consumer.subscribe(Collections.singletonList(topic));
   }
@@ -58,20 +54,6 @@ public class KafkaConsumerSampler extends AbstractJavaSamplerClient implements S
     timeout = Long.parseLong(props.getProperty("timeout.millis"));
     log.debug("Populated properties: {}", props);
     return props;
-  }
-
-  private void configGenericData() {
-    final var genericData = GenericData.get();
-
-    genericData.addLogicalTypeConversion(new TimeConversions.DateConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
-    genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
-    genericData.addLogicalTypeConversion(new Conversions.UUIDConversion());
   }
 
   @Override

--- a/src/main/java/net/coru/kloadgen/sampler/KafkaProducerSampler.java
+++ b/src/main/java/net/coru/kloadgen/sampler/KafkaProducerSampler.java
@@ -25,9 +25,6 @@ import net.coru.kloadgen.serializer.EnrichedRecord;
 import net.coru.kloadgen.serializer.ProtobufSerializer;
 import net.coru.kloadgen.util.ProducerKeysHelper;
 import net.coru.kloadgen.util.PropsKeysHelper;
-import org.apache.avro.Conversions;
-import org.apache.avro.data.TimeConversions;
-import org.apache.avro.generic.GenericData;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient;
@@ -44,16 +41,27 @@ import org.apache.kafka.common.KafkaException;
 public final class KafkaProducerSampler extends AbstractJavaSamplerClient implements Serializable {
 
   private static final String TEMPLATE = "Topic: %s, partition: %s, offset: %s";
+
   private static final Set<String> SERIALIZER_SET = Set.of(AvroSerializer.class.getName(), ProtobufSerializer.class.getName());
+
   private static final long serialVersionUID = 1L;
+
   private final transient StatelessGeneratorTool statelessGeneratorTool = new StatelessGeneratorTool();
+
   private transient KafkaProducer<Object, Object> producer;
+
   private String topic;
+
   private String msgKeyType;
+
   private List<String> msgKeyValue;
+
   private boolean keyMessageFlag = false;
+
   private transient BaseLoadGenerator generator;
+
   private transient BaseLoadGenerator keyGenerator;
+
   private transient Properties props;
 
   @Override
@@ -61,8 +69,6 @@ public final class KafkaProducerSampler extends AbstractJavaSamplerClient implem
     props = properties(context);
 
     generator = SamplerUtil.configureValueGenerator(props);
-
-    configGenericData();
 
     if ("true".equals(context.getJMeterVariables().get(PropsKeysHelper.SCHEMA_KEYED_MESSAGE_KEY))
         || "true".equals(context.getJMeterVariables().get(PropsKeysHelper.SIMPLE_KEYED_MESSAGE_KEY))) {
@@ -72,7 +78,7 @@ public final class KafkaProducerSampler extends AbstractJavaSamplerClient implem
       } else {
         msgKeyType = props.getProperty(PropsKeysHelper.MESSAGE_KEY_KEY_TYPE);
         msgKeyValue = PropsKeysHelper.MSG_KEY_VALUE.equalsIgnoreCase(props.getProperty(PropsKeysHelper.MESSAGE_KEY_KEY_VALUE))
-                        ? Collections.emptyList() : Collections.singletonList(props.getProperty(PropsKeysHelper.MESSAGE_KEY_KEY_VALUE));
+                          ? Collections.emptyList() : Collections.singletonList(props.getProperty(PropsKeysHelper.MESSAGE_KEY_KEY_VALUE));
       }
     } else {
       props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ProducerKeysHelper.KEY_SERIALIZER_CLASS_CONFIG_DEFAULT);
@@ -92,20 +98,6 @@ public final class KafkaProducerSampler extends AbstractJavaSamplerClient implem
       commonProps.put(ProducerKeysHelper.VALUE_NAME_STRATEGY, context.getParameter(ProducerKeysHelper.VALUE_NAME_STRATEGY));
     }
     return commonProps;
-  }
-
-  private void configGenericData() {
-    final var genericData = GenericData.get();
-
-    genericData.addLogicalTypeConversion(new TimeConversions.DateConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
-    genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
-    genericData.addLogicalTypeConversion(new Conversions.UUIDConversion());
   }
 
   @Override

--- a/src/main/java/net/coru/kloadgen/serializer/AvroSerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/AvroSerializer.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import javax.xml.bind.DatatypeConverter;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
@@ -26,6 +25,10 @@ public class AvroSerializer<T extends EnrichedRecord> implements Serializer<T> {
   private static final byte MAGIC_BYTE = 0x0;
 
   private static final int ID_SIZE = 4;
+
+  public AvroSerializer() {
+    AvroSerializersUtil.setupLogicalTypesConversion();
+  }
 
   @Override
   public final byte[] serialize(final String topic, final T data) {

--- a/src/main/java/net/coru/kloadgen/serializer/AvroSerializersUtil.java
+++ b/src/main/java/net/coru/kloadgen/serializer/AvroSerializersUtil.java
@@ -1,0 +1,22 @@
+package net.coru.kloadgen.serializer;
+
+import org.apache.avro.Conversions;
+import org.apache.avro.data.TimeConversions;
+import org.apache.avro.generic.GenericData;
+
+public class AvroSerializersUtil {
+
+  public static void setupLogicalTypesConversion() {
+    final var genericData = GenericData.get();
+
+    genericData.addLogicalTypeConversion(new TimeConversions.DateConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+    genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
+    genericData.addLogicalTypeConversion(new Conversions.UUIDConversion());
+  }
+}

--- a/src/main/java/net/coru/kloadgen/serializer/AvroSerializersUtil.java
+++ b/src/main/java/net/coru/kloadgen/serializer/AvroSerializersUtil.java
@@ -4,7 +4,10 @@ import org.apache.avro.Conversions;
 import org.apache.avro.data.TimeConversions;
 import org.apache.avro.generic.GenericData;
 
-public class AvroSerializersUtil {
+public final class AvroSerializersUtil {
+
+  private AvroSerializersUtil() {
+  }
 
   public static void setupLogicalTypesConversion() {
     final var genericData = GenericData.get();

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
@@ -24,7 +24,7 @@ public class GenericAvroRecordBinarySerializer<T extends GenericRecord> implemen
 
   @Override
   public final byte[] serialize(final String s, final T data) {
-    DatumWriter<T> writer;
+    final DatumWriter<T> writer;
     if (data instanceof SpecificRecord) {
       writer = new SpecificDatumWriter<>(data.getSchema());
     } else {

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
@@ -10,9 +10,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 
@@ -21,7 +24,12 @@ public class GenericAvroRecordBinarySerializer<T extends GenericRecord> implemen
 
   @Override
   public final byte[] serialize(final String s, final T data) {
-    final var writer = new SpecificDatumWriter<>(data.getSchema());
+    DatumWriter<T> writer = new GenericDatumWriter<>(data.getSchema());
+    if (data instanceof SpecificRecord) {
+      writer = new SpecificDatumWriter<>(data.getSchema());
+    } else {
+      writer = new GenericDatumWriter<>(data.getSchema());
+    }
     var result = new byte[]{};
     try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       final var encoder = EncoderFactory.get().binaryEncoder(baos, null);

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
@@ -14,8 +14,6 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
-import org.apache.avro.specific.SpecificDatumWriter;
-import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
@@ -24,12 +24,8 @@ public class GenericAvroRecordBinarySerializer<T extends GenericRecord> implemen
 
   @Override
   public final byte[] serialize(final String s, final T data) {
-    final DatumWriter<T> writer;
-    if (data instanceof SpecificRecord) {
-      writer = new SpecificDatumWriter<>(data.getSchema());
-    } else {
-      writer = new GenericDatumWriter<>(data.getSchema());
-    }
+    final DatumWriter<T> writer = new GenericDatumWriter<>(data.getSchema());
+
     var result = new byte[]{};
     try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       final var encoder = EncoderFactory.get().binaryEncoder(baos, null);

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
@@ -24,7 +24,7 @@ public class GenericAvroRecordBinarySerializer<T extends GenericRecord> implemen
 
   @Override
   public final byte[] serialize(final String s, final T data) {
-    DatumWriter<T> writer = new GenericDatumWriter<>(data.getSchema());
+    DatumWriter<T> writer;
     if (data instanceof SpecificRecord) {
       writer = new SpecificDatumWriter<>(data.getSchema());
     } else {

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordBinarySerializer.java
@@ -20,6 +20,10 @@ import org.apache.kafka.common.serialization.Serializer;
 @Slf4j
 public class GenericAvroRecordBinarySerializer<T extends GenericRecord> implements Serializer<T> {
 
+  public GenericAvroRecordBinarySerializer() {
+    AvroSerializersUtil.setupLogicalTypesConversion();
+  }
+
   @Override
   public final byte[] serialize(final String s, final T data) {
     final DatumWriter<T> writer = new GenericDatumWriter<>(data.getSchema());

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
@@ -21,6 +21,10 @@ import org.apache.kafka.common.serialization.Serializer;
 @Slf4j
 public class GenericAvroRecordSerializer<T extends GenericRecord> implements Serializer<T> {
 
+  public GenericAvroRecordSerializer() {
+    AvroSerializersUtil.setupLogicalTypesConversion();
+  }
+
   @Override
   public final byte[] serialize(final String topic, final T data) {
     final DatumWriter<T> writer = new GenericDatumWriter<>(data.getSchema());

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
@@ -10,10 +10,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 
@@ -23,7 +26,13 @@ public class GenericAvroRecordSerializer<T extends GenericRecord> implements Ser
   @Override
   public final byte[] serialize(final String topic, final T data) {
 
-    final var writer = new SpecificDatumWriter<>(data.getSchema());
+    DatumWriter<T> writer = new GenericDatumWriter<>(data.getSchema());
+    if (data instanceof SpecificRecord) {
+      writer = new SpecificDatumWriter<>(data.getSchema());
+    } else {
+      writer = new GenericDatumWriter<>(data.getSchema());
+    }
+
     byte[] dataBytes = new byte[0];
     final var stream = new ByteArrayOutputStream();
     final Encoder jsonEncoder;

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
@@ -26,7 +26,7 @@ public class GenericAvroRecordSerializer<T extends GenericRecord> implements Ser
   @Override
   public final byte[] serialize(final String topic, final T data) {
 
-    DatumWriter<T> writer;
+    final DatumWriter<T> writer;
     if (data instanceof SpecificRecord) {
       writer = new SpecificDatumWriter<>(data.getSchema());
     } else {

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
@@ -25,13 +25,7 @@ public class GenericAvroRecordSerializer<T extends GenericRecord> implements Ser
 
   @Override
   public final byte[] serialize(final String topic, final T data) {
-
-    final DatumWriter<T> writer;
-    if (data instanceof SpecificRecord) {
-      writer = new SpecificDatumWriter<>(data.getSchema());
-    } else {
-      writer = new GenericDatumWriter<>(data.getSchema());
-    }
+    final DatumWriter<T> writer = new GenericDatumWriter<>(data.getSchema());
 
     byte[] dataBytes = new byte[0];
     final var stream = new ByteArrayOutputStream();

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
@@ -15,8 +15,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
-import org.apache.avro.specific.SpecificDatumWriter;
-import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 

--- a/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
+++ b/src/main/java/net/coru/kloadgen/serializer/GenericAvroRecordSerializer.java
@@ -26,7 +26,7 @@ public class GenericAvroRecordSerializer<T extends GenericRecord> implements Ser
   @Override
   public final byte[] serialize(final String topic, final T data) {
 
-    DatumWriter<T> writer = new GenericDatumWriter<>(data.getSchema());
+    DatumWriter<T> writer;
     if (data instanceof SpecificRecord) {
       writer = new SpecificDatumWriter<>(data.getSchema());
     } else {

--- a/src/test/java/net/coru/kloadgen/serializer/AvroSerializersTest.java
+++ b/src/test/java/net/coru/kloadgen/serializer/AvroSerializersTest.java
@@ -14,13 +14,9 @@ import net.coru.kloadgen.extractor.impl.SchemaExtractorImpl;
 import net.coru.kloadgen.model.FieldValueMapping;
 import net.coru.kloadgen.processor.SchemaProcessor;
 import net.coru.kloadgen.testutil.FileHelper;
-import org.apache.avro.Conversions;
-import org.apache.avro.data.TimeConversions;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.common.serialization.Serializer;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -36,49 +32,22 @@ public class AvroSerializersTest {
     );
   }
 
-  @BeforeEach
-  void setUp() {
-    final var genericData = GenericData.get();
-
-    genericData.addLogicalTypeConversion(new TimeConversions.DateConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
-    genericData.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
-    genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
-    genericData.addLogicalTypeConversion(new Conversions.UUIDConversion());
-  }
-
   @ParameterizedTest
   @MethodSource("getSerializers")
   void recordSerializersTestLogicalTypes(final Serializer<GenericRecord> serializer) throws Exception {
     final var schemaFile = new FileHelper().getFile("/avro-files/testLogicalTypes.avsc");
     final var schemaStr = readSchema(schemaFile);
     final var fieldValueMappings = Arrays.asList(
-        FieldValueMapping.builder().fieldName("Date").fieldType("int_date").valueLength(0).fieldValueList("[]").required(true)
-                         .isAncestorRequired(true).build(),
-        FieldValueMapping.builder().fieldName("TimeMillis").fieldType("int_time-millis").valueLength(0).fieldValueList("[]").required(true)
-                         .isAncestorRequired(true).build(),
-        FieldValueMapping.builder().fieldName("TimeMicros").fieldType("long_time-micros").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                         .build(),
-        FieldValueMapping.builder().fieldName("TimestampMillis").fieldType("long_timestamp-millis").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                         .build(),
-        FieldValueMapping.builder().fieldName("TimestampMicros").fieldType("long_timestamp-micros").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                         .build(),
-        FieldValueMapping.builder().fieldName("LocalTimestampMillis").fieldType("long_local-timestamp-millis").valueLength(0).fieldValueList("[]").required(true)
-                         .isAncestorRequired(true)
-                         .build(),
-        FieldValueMapping.builder().fieldName("LocalTimestampMicros").fieldType("long_local-timestamp-micros").valueLength(0).fieldValueList("[]").required(true)
-                         .isAncestorRequired(true)
-                         .build(),
-        FieldValueMapping.builder().fieldName("UUID").fieldType("string_uuid").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                         .build(),
-        FieldValueMapping.builder().fieldName("Decimal").fieldType("bytes_decimal").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                         .build(),
-        FieldValueMapping.builder().fieldName("DecimalFixed").fieldType("fixed_decimal").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                         .build());
+        createFieldValueMapping("Date", "int_date"),
+        createFieldValueMapping("TimeMillis", "int_time-millis"),
+        createFieldValueMapping("TimeMicros", "long_time-micros"),
+        createFieldValueMapping("TimestampMillis", "long_timestamp-millis"),
+        createFieldValueMapping("TimestampMicros", "long_timestamp-micros"),
+        createFieldValueMapping("LocalTimestampMillis", "long_local-timestamp-millis"),
+        createFieldValueMapping("LocalTimestampMicros", "long_local-timestamp-micros"),
+        createFieldValueMapping("UUID", "string_uuid"),
+        createFieldValueMapping("Decimal", "bytes_decimal"),
+        createFieldValueMapping("DecimalFixed", "fixed_decimal"));
     final var metadata = new SchemaMetadata(1, 1, schemaStr);
 
     final ParsedSchema parsedSchema = new SchemaExtractorImpl().schemaTypesList(schemaFile, "AVRO");
@@ -98,5 +67,10 @@ public class AvroSerializersTest {
     }
 
     return contentBuilder.toString();
+  }
+
+  private FieldValueMapping createFieldValueMapping(String name, String fieldType) {
+    return FieldValueMapping.builder().fieldName(name).fieldType(fieldType).valueLength(0).fieldValueList("[]").required(true)
+                            .isAncestorRequired(true).build();
   }
 }

--- a/src/test/java/net/coru/kloadgen/serializer/AvroSerializersTest.java
+++ b/src/test/java/net/coru/kloadgen/serializer/AvroSerializersTest.java
@@ -1,5 +1,12 @@
 package net.coru.kloadgen.serializer;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import net.coru.kloadgen.common.SchemaTypeEnum;
@@ -17,83 +24,79 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.stream.Stream;
 
 public class AvroSerializersTest {
 
-    private static final SchemaProcessor AVRO_SCHEMA_PROCESSOR = new SchemaProcessor();
+  private static final SchemaProcessor AVRO_SCHEMA_PROCESSOR = new SchemaProcessor();
 
-    @BeforeEach
-    void setUp() {
-        final var genericData = GenericData.get();
+  private static Stream<Arguments> getSerializers() {
+    return Stream.of(
+        Arguments.arguments(new GenericAvroRecordSerializer<>()),
+        Arguments.arguments(new GenericAvroRecordBinarySerializer<>())
+    );
+  }
 
-        genericData.addLogicalTypeConversion(new TimeConversions.DateConversion());
-        genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
-        genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
-        genericData.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
-        genericData.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
-        genericData.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
-        genericData.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
-        genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
-        genericData.addLogicalTypeConversion(new Conversions.UUIDConversion());
+  @BeforeEach
+  void setUp() {
+    final var genericData = GenericData.get();
+
+    genericData.addLogicalTypeConversion(new TimeConversions.DateConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
+    genericData.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+    genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
+    genericData.addLogicalTypeConversion(new Conversions.UUIDConversion());
+  }
+
+  @ParameterizedTest
+  @MethodSource("getSerializers")
+  void recordSerializersTestLogicalTypes(final Serializer<GenericRecord> serializer) throws Exception {
+    final var schemaFile = new FileHelper().getFile("/avro-files/testLogicalTypes.avsc");
+    final var schemaStr = readSchema(schemaFile);
+    final var fieldValueMappings = Arrays.asList(
+        FieldValueMapping.builder().fieldName("Date").fieldType("int_date").valueLength(0).fieldValueList("[]").required(true)
+                         .isAncestorRequired(true).build(),
+        FieldValueMapping.builder().fieldName("TimeMillis").fieldType("int_time-millis").valueLength(0).fieldValueList("[]").required(true)
+                         .isAncestorRequired(true).build(),
+        FieldValueMapping.builder().fieldName("TimeMicros").fieldType("long_time-micros").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                         .build(),
+        FieldValueMapping.builder().fieldName("TimestampMillis").fieldType("long_timestamp-millis").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                         .build(),
+        FieldValueMapping.builder().fieldName("TimestampMicros").fieldType("long_timestamp-micros").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                         .build(),
+        FieldValueMapping.builder().fieldName("LocalTimestampMillis").fieldType("long_local-timestamp-millis").valueLength(0).fieldValueList("[]").required(true)
+                         .isAncestorRequired(true)
+                         .build(),
+        FieldValueMapping.builder().fieldName("LocalTimestampMicros").fieldType("long_local-timestamp-micros").valueLength(0).fieldValueList("[]").required(true)
+                         .isAncestorRequired(true)
+                         .build(),
+        FieldValueMapping.builder().fieldName("UUID").fieldType("string_uuid").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                         .build(),
+        FieldValueMapping.builder().fieldName("Decimal").fieldType("bytes_decimal").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                         .build(),
+        FieldValueMapping.builder().fieldName("DecimalFixed").fieldType("fixed_decimal").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                         .build());
+    final var metadata = new SchemaMetadata(1, 1, schemaStr);
+
+    final ParsedSchema parsedSchema = new SchemaExtractorImpl().schemaTypesList(schemaFile, "AVRO");
+    AVRO_SCHEMA_PROCESSOR.processSchema(SchemaTypeEnum.AVRO, parsedSchema, metadata, fieldValueMappings);
+    final var generatedRecord = AVRO_SCHEMA_PROCESSOR.next();
+
+    final var message = serializer.serialize("the-topic", (GenericRecord) ((EnrichedRecord) generatedRecord).getGenericRecord());
+
+    Assertions.assertThat(message).isNotNull();
+  }
+
+  private static String readSchema(final File file) throws IOException {
+    final StringBuilder contentBuilder = new StringBuilder();
+
+    try (Stream<String> stream = Files.lines(file.toPath(), StandardCharsets.UTF_8)) {
+      stream.forEach(s -> contentBuilder.append(s).append("\n"));
     }
 
-    @ParameterizedTest
-    @MethodSource("getSerializers")
-    void recordSerializersTestLogicalTypes(Serializer serializer) throws Exception {
-        final var schemaFile = new FileHelper().getFile("/avro-files/testLogicalTypes.avsc");
-        final var schemaStr = readSchema(schemaFile);
-        final var fieldValueMappings = Arrays.asList(
-                FieldValueMapping.builder().fieldName("Date").fieldType("int_date").valueLength(0).fieldValueList("[]").required(true)
-                        .isAncestorRequired(true).build(),
-                FieldValueMapping.builder().fieldName("TimeMillis").fieldType("int_time-millis").valueLength(0).fieldValueList("[]").required(true)
-                        .isAncestorRequired(true).build(),
-                FieldValueMapping.builder().fieldName("TimeMicros").fieldType("long_time-micros").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                        .build(),
-                FieldValueMapping.builder().fieldName("TimestampMillis").fieldType("long_timestamp-millis").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                        .build(),
-                FieldValueMapping.builder().fieldName("TimestampMicros").fieldType("long_timestamp-micros").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                        .build(),
-                FieldValueMapping.builder().fieldName("LocalTimestampMillis").fieldType("long_local-timestamp-millis").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                        .build(),
-                FieldValueMapping.builder().fieldName("LocalTimestampMicros").fieldType("long_local-timestamp-micros").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                        .build(),
-                FieldValueMapping.builder().fieldName("UUID").fieldType("string_uuid").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                        .build(),
-                FieldValueMapping.builder().fieldName("Decimal").fieldType("bytes_decimal").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                        .build(),
-                FieldValueMapping.builder().fieldName("DecimalFixed").fieldType("fixed_decimal").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
-                        .build());
-        final var metadata = new SchemaMetadata(1, 1, schemaStr);
-
-        final ParsedSchema parsedSchema = new SchemaExtractorImpl().schemaTypesList(schemaFile, "AVRO");
-        AVRO_SCHEMA_PROCESSOR.processSchema(SchemaTypeEnum.AVRO, parsedSchema, metadata, fieldValueMappings);
-        final var generatedRecord = AVRO_SCHEMA_PROCESSOR.next();
-
-        final var message = serializer.serialize("the-topic", (GenericRecord) ((EnrichedRecord) generatedRecord).getGenericRecord());
-
-        Assertions.assertThat(message).isNotNull();
-    }
-
-    private static Stream<Arguments> getSerializers() {
-        return Stream.of(
-                Arguments.arguments(new GenericAvroRecordSerializer()),
-                Arguments.arguments(new GenericAvroRecordBinarySerializer())
-        );
-    }
-
-    private static String readSchema(final File file) throws IOException {
-        final StringBuilder contentBuilder = new StringBuilder();
-
-        try (Stream<String> stream = Files.lines(file.toPath(), StandardCharsets.UTF_8)) {
-            stream.forEach(s -> contentBuilder.append(s).append("\n"));
-        }
-
-        return contentBuilder.toString();
-    }
+    return contentBuilder.toString();
+  }
 }

--- a/src/test/java/net/coru/kloadgen/serializer/AvroSerializersTest.java
+++ b/src/test/java/net/coru/kloadgen/serializer/AvroSerializersTest.java
@@ -1,0 +1,99 @@
+package net.coru.kloadgen.serializer;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import net.coru.kloadgen.common.SchemaTypeEnum;
+import net.coru.kloadgen.extractor.impl.SchemaExtractorImpl;
+import net.coru.kloadgen.model.FieldValueMapping;
+import net.coru.kloadgen.processor.SchemaProcessor;
+import net.coru.kloadgen.testutil.FileHelper;
+import org.apache.avro.Conversions;
+import org.apache.avro.data.TimeConversions;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.serialization.Serializer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public class AvroSerializersTest {
+
+    private static final SchemaProcessor AVRO_SCHEMA_PROCESSOR = new SchemaProcessor();
+
+    @BeforeEach
+    void setUp() {
+        final var genericData = GenericData.get();
+
+        genericData.addLogicalTypeConversion(new TimeConversions.DateConversion());
+        genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
+        genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
+        genericData.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
+        genericData.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
+        genericData.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
+        genericData.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+        genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
+        genericData.addLogicalTypeConversion(new Conversions.UUIDConversion());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getSerializers")
+    void recordSerializersTestLogicalTypes(Serializer serializer) throws Exception {
+        final var schemaFile = new FileHelper().getFile("/avro-files/testLogicalTypes.avsc");
+        final var schemaStr = readSchema(schemaFile);
+        final var fieldValueMappings = Arrays.asList(
+                FieldValueMapping.builder().fieldName("Date").fieldType("int_date").valueLength(0).fieldValueList("[]").required(true)
+                        .isAncestorRequired(true).build(),
+                FieldValueMapping.builder().fieldName("TimeMillis").fieldType("int_time-millis").valueLength(0).fieldValueList("[]").required(true)
+                        .isAncestorRequired(true).build(),
+                FieldValueMapping.builder().fieldName("TimeMicros").fieldType("long_time-micros").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                        .build(),
+                FieldValueMapping.builder().fieldName("TimestampMillis").fieldType("long_timestamp-millis").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                        .build(),
+                FieldValueMapping.builder().fieldName("TimestampMicros").fieldType("long_timestamp-micros").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                        .build(),
+                FieldValueMapping.builder().fieldName("LocalTimestampMillis").fieldType("long_local-timestamp-millis").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                        .build(),
+                FieldValueMapping.builder().fieldName("LocalTimestampMicros").fieldType("long_local-timestamp-micros").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                        .build(),
+                FieldValueMapping.builder().fieldName("UUID").fieldType("string_uuid").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                        .build(),
+                FieldValueMapping.builder().fieldName("Decimal").fieldType("bytes_decimal").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                        .build(),
+                FieldValueMapping.builder().fieldName("DecimalFixed").fieldType("fixed_decimal").valueLength(0).fieldValueList("[]").required(true).isAncestorRequired(true)
+                        .build());
+        final var metadata = new SchemaMetadata(1, 1, schemaStr);
+
+        final ParsedSchema parsedSchema = new SchemaExtractorImpl().schemaTypesList(schemaFile, "AVRO");
+        AVRO_SCHEMA_PROCESSOR.processSchema(SchemaTypeEnum.AVRO, parsedSchema, metadata, fieldValueMappings);
+        final var generatedRecord = AVRO_SCHEMA_PROCESSOR.next();
+
+        final var message = serializer.serialize("the-topic", (GenericRecord) ((EnrichedRecord) generatedRecord).getGenericRecord());
+
+        Assertions.assertThat(message).isNotNull();
+    }
+
+    private static Stream<Arguments> getSerializers() {
+        return Stream.of(
+                Arguments.arguments(new GenericAvroRecordSerializer()),
+                Arguments.arguments(new GenericAvroRecordBinarySerializer())
+        );
+    }
+
+    private static String readSchema(final File file) throws IOException {
+        final StringBuilder contentBuilder = new StringBuilder();
+
+        try (Stream<String> stream = Files.lines(file.toPath(), StandardCharsets.UTF_8)) {
+            stream.forEach(s -> contentBuilder.append(s).append("\n"));
+        }
+
+        return contentBuilder.toString();
+    }
+}

--- a/src/test/java/net/coru/kloadgen/serializer/AvroSerializersTest.java
+++ b/src/test/java/net/coru/kloadgen/serializer/AvroSerializersTest.java
@@ -69,7 +69,7 @@ public class AvroSerializersTest {
     return contentBuilder.toString();
   }
 
-  private FieldValueMapping createFieldValueMapping(String name, String fieldType) {
+  private FieldValueMapping createFieldValueMapping(final String name, final String fieldType) {
     return FieldValueMapping.builder().fieldName(name).fieldType(fieldType).valueLength(0).fieldValueList("[]").required(true)
                             .isAncestorRequired(true).build();
   }


### PR DESCRIPTION
The casting problem of long_timestamp-millis gets solved when using the GenericDatumWriter. Despite the lack of documentation it seems that we should use SpecificDatumWriter only when needed.